### PR TITLE
Disable spellcheck in playground editor

### DIFF
--- a/js/Playground/Tabs/EditorTab.js
+++ b/js/Playground/Tabs/EditorTab.js
@@ -25,7 +25,8 @@ export const EditorTab = function(tabs, data) {
 		resize: 'none',
 		tab: true,
 		autoIndent: true,
-		styles: null
+		styles: null,
+		spellcheck: true
 	});
 
 	const scrollable = editor.textarea;

--- a/js/Playground/Tabs/EditorTab.js
+++ b/js/Playground/Tabs/EditorTab.js
@@ -26,7 +26,7 @@ export const EditorTab = function(tabs, data) {
 		tab: true,
 		autoIndent: true,
 		styles: null,
-		spellcheck: true
+		spellcheck: false
 	});
 
 	const scrollable = editor.textarea;


### PR DESCRIPTION
While working on one of the quizzes that use the playground, I found myself fighting with both Grammarly and the builtin Chrome spellchecker. It seems logical to disable spellchecking here as code in most languages will contain "words" which aren't English words.

The change uses code implemented already in the Editor from the site-cl repo [here](https://github.com/charles-owen/site-cl/blob/0906c976965484b82c0b0de7dc7c8ce2399cb7ba/js/UI/Editor.js#L69).

I can't easily test this change because I'm not sure it would even be possible without pulling down a bunch more `cl` repos, but it *should* work.